### PR TITLE
Revert "use the travis user token"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
 deploy:
     strategy: git
     provider: pages
-    token: $GH_TRAVIS_TOKEN
+    token: $GH_REPO_TOKEN
     keep_history: true
     local_dir: build
     target_branch: gh-pages


### PR DESCRIPTION
travis deploy does not work anymore because token which was used has been changed from GH_REPO_TOKEN to ..TRAVIS_TOKEN
but it did not work before either