### PR TITLE
Revert "try use another keyword (travis api)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
 deploy:
     strategy: git
     provider: pages
-    cleanup: false
+    skip_cleanup: true
     token: $GH_TRAVIS_TOKEN
     keep_history: true
     local_dir: build


### PR DESCRIPTION
This reverts commit e2302fb3e66091e8f13c911b62fc662bdde3627c.

Otherwise deploy to gh-pages does not work,
even if fixing induces build config warning